### PR TITLE
Yaay display language issue solved

### DIFF
--- a/views/_issue.erb
+++ b/views/_issue.erb
@@ -17,6 +17,7 @@
   <% unless issue.body.nil? %>
     <div class="body">
       <%= issue.body %>
+      <%= Octokit.repo(issue.repo)[:language] %>
     </div>
   <% end %>
     <div class="details row">


### PR DESCRIPTION
Just added a line so that language of the project will be shown at the end.

Fix for https://github.com/despo/kobol/issues/4
- Karthikeyan A K (Spritle Software)
