### PR TITLE
Improving the display of last updated timestamp with no comment

### DIFF
--- a/views/_issue.erb
+++ b/views/_issue.erb
@@ -20,12 +20,16 @@
     </div>
   <% end %>
     <div class="details row">
-      <span class="small-6 columns text-left">
-        Updated <%=issue.updated_at%>
-      </span>
       <% if issue.comments > 0 %>
-        <span class="small-6 columns text-right">
-          <%=issue.comments%> Comments
+      <span class="small-6 columns text-left">
+        Updated <%= issue.updated_at %>
+      </span>
+      <span class="small-6 columns text-right">
+        <%= issue.comments %> Comments
+      </span>
+      <% else %>
+        <span class="columns text-left">
+          Updated <%= issue.updated_at %>
         </span>
       <% end %>
     </div>


### PR DESCRIPTION
When there are no comments on a narrow viewport, the timestamp of an issue looked very squished:
![screen shot 2014-12-16 at 21 25 00](https://cloud.githubusercontent.com/assets/1315463/5462280/53fdbe24-856a-11e4-87f2-6d30da3eaa2e.png)

This fixes it by adding a full row if there are no comments:
![screen shot 2014-12-16 at 21 25 34](https://cloud.githubusercontent.com/assets/1315463/5462289/5f5a6d30-856a-11e4-92dc-e08881f8adbd.png)
