### PR TITLE
Issue labels now clickable and filterable

### DIFF
--- a/views/_issue.erb
+++ b/views/_issue.erb
@@ -2,9 +2,11 @@
   <ul class='labels'>
     <% issue.labels.each do |label| %>
       <li>
-        <span class='label' style='background-color: <%= label.color %>;'>
+        <a href="/?label[]=<%= CGI.escape label.name %>">
+          <span class='label' style='background-color: <%= label.color %>;'>
           <%= label.name %>
-        </span>
+          </span>
+        </a>
       </li>
     <% end %>
   </ul>


### PR DESCRIPTION
It's a common UI convention to be able to click on faceted-search labels to further filter them down.

The way I've implemented this is probably far from ideal, so if there's a more Rails-y way of implementing this I'd appreciate any pointers. :+1:
