### PR TITLE
add target blank to repo subheader

### DIFF
--- a/views/_issue.erb
+++ b/views/_issue.erb
@@ -14,7 +14,7 @@
     <a href="<%= issue.url %>" target="_blank"><%=  issue.title %></a>
   </h4>
   <h5 class="subheader">
-    <a class="repo" href="http://github.com/<%= issue.repo %>"> <%= issue.repo %> </a>
+    <a class="repo" href="http://github.com/<%= issue.repo %>" target="_blank"> <%= issue.repo %> </a>
   </h5>
   <% unless issue.body.nil? %>
     <div class="body">


### PR DESCRIPTION
the repo sub header is missing `target="_blank"`
