### PR TITLE
Add an ellipsis to the placeholder text in the language textbox

### DIFF
--- a/views/_search.erb
+++ b/views/_search.erb
@@ -50,7 +50,7 @@
         language
       </div>
       <div class="large-3 columns">
-        <input type="text" name="language" placeholder="ruby, javascript" id="language" value="<%=params["language"] %>" />
+        <input type="text" name="language" placeholder="ruby, javascript, ..." id="language" value="<%=params["language"] %>" />
       </div>
       <div class="large-1 columns">
         <input class="button search large expand"type="submit" id="language" value="Find"></input>


### PR DESCRIPTION
- Initially, I thought that the only two available languages to search
  for were Ruby and Javascript, then I tried Python and it returned
  results. Avoid this for other people by adding `...` to the
  placeholder text.