### PR TITLE
fix label color for firefox

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -222,8 +222,6 @@ input[type="checkbox"] + label {
   -moz-box-shadow: inset 0 50px 0 #b0b0b0;
   -webkit-box-shadow: inset 0 50px 0 #b0b0b0;
   box-shadow: inset 0 50px 0 #b0b0b0;
-  filter: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><filter id=\'grayscale\'><feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/></filter></svg>#grayscale"); /* Firefox 10+, Firefox on Android */
-
 }
 
 input[type="checkbox"] {


### PR DESCRIPTION
The filter was causing issues on FF and would still apply a grayscale instead of a solid color.