### PR TITLE
Made colors accessible

### DIFF
--- a/lib/kobol/helpers/requests.rb
+++ b/lib/kobol/helpers/requests.rb
@@ -1,20 +1,20 @@
 module Kobol::Helpers
   module Requests
-    LABELS = {  'help wanted' => '159818',
-                documentation: 'e395c9' ,
+    LABELS = {  'help wanted' => '128014',
+                documentation: '996588' ,
                 bug: 'e70b41',
-                trivial: '25bdf1',
-                feature: '3c9d4a',
-                enhancement: '71a1d0',
-                design: '25bdf1' ,
-                refactoring: 'a095c4' ,
-                tests: 'd66038' ,
-                translation: '34d081' ,
-                beginner: 'b89055' ,
-                html: 'f11abc' ,
+                trivial: '136480',
+                feature: '35563a',
+                enhancement: '537699',
+                design: '1f5466' ,
+                refactoring: '686180' ,
+                tests: 'b34f2e' ,
+                translation: '208050' ,
+                beginner: '66410a' ,
+                html: 'd918a9' ,
                 question: 'cc317c',
-                accessibility: '3c9d4a',
-                'easy pick' => 'fbca04' }
+                accessibility: '30803c',
+                'easy pick' => 'b3560b' }
 
     def github(message=nil, not_found_message=nil)
       yield

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -217,11 +217,11 @@ footer {
 
 input[type="checkbox"] + label {
   font-size: 1.2em;
-  margin: 2px 0;
+  margin: 2px 1px;
   font-weight: 400;
-  -moz-box-shadow: inset 0 50px 0 #b0b0b0;
-  -webkit-box-shadow: inset 0 50px 0 #b0b0b0;
-  box-shadow: inset 0 50px 0 #b0b0b0;
+  -moz-box-shadow: inset 0 50px 0 #5e5e5e; 
+ -webkit-box-shadow: inset 0 50px 0 #5e5e5e;
+    box-shadow: inset 0 50px 0 #5e5e5e;
 }
 
 input[type="checkbox"] {
@@ -235,17 +235,17 @@ input[type="checkbox"] {
 input[type="checkbox"]:checked + label {
   opacity: 1;
   font-weight: 400;
-  -moz-box-shadow: none;
-  -webkit-box-shadow: none;
-  box-shadow: none;
+-webkit-box-shadow: 3px 3px 5px 0px rgba(0,0,0,0.5);
+-moz-box-shadow: 3px 3px 5px 0px rgba(0,0,0,0.5);
+box-shadow: 3px 3px 5px 0px rgba(0,0,0,0.5);
 }
 
 .label.help-wanted {
-  background-color: #159818;
+  background-color: #128014;
 }
 
 .label.documentation {
-  background-color: #e395c9;
+  background-color: #996588;
 }
 
 .label.bug {
@@ -253,47 +253,47 @@ input[type="checkbox"]:checked + label {
 }
 
 .label.trivial {
-  background-color: #25bdf1;
+  background-color: #136480;
 }
 
 .label.feature {
-  background-color: #3c9d4a;
+  background-color: #35563a;
 }
 
 .label.enhancement {
-  background-color: #71a1d0;
+  background-color: #537699;
 }
 
 .label.design {
-  background-color: #25bdf1
+  background-color: #1f5466;
 }
 
 .label.refactoring {
-  background-color: #a095c4;
+  background-color: #686180;
 }
 
 .label.tests {
-  background-color: #d66038;
+  background-color: #b34f2e;
 }
 
 .label.html {
-  background-color: #f11abc;
+  background-color: #d918a9;
 }
 
 .label.translation {
-  background-color: #34d081;
+  background-color: #208050;
 }
 
 .label.beginner {
-  background-color: #b89055;
+  background-color: #66410a;
 }
 
 .label.accessibility {
-  background-color: #3c9d4a;
+  background-color: #30803c;
 }
 
 .label.easy-pick {
-  background-color: #fbca04;
+  background-color: #b3560b;
 }
 
 .description {


### PR DESCRIPTION
All colours now have at least an AA accessibility rating for their
contrast on all text sizes. Drop shadow has been added on check to help
those who are colourblind distinguished between checked and unchecked
buttons.

Good temp fix before redesign.

Fixes #53

![screen shot 2015-12-05 at 12 47 04](https://cloud.githubusercontent.com/assets/11182042/11607864/a60e28b0-9b4f-11e5-8903-8aba84c35ab3.png)

Thanks to @codebar and @ladieswhocode 