### PR TITLE
Add (dynamically) the current year to the copyright section

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -47,7 +47,7 @@
   <div class="row">
     <div class="large-6 columns">
       <ul class='inline-list footer-links'>
-        <li>Copyright 2013-2018</li>
+        <li>Copyright 2013-<%= Date.today.year %></li>
         <li><a href='/privacy-policy'>Privacy Policy</a></li>
       </ul>
     </div>


### PR DESCRIPTION
This feature uses the `Date.today.year` to add the current year in the copyright section, so you don't need to update it every year manually.